### PR TITLE
Small fixes for Kaldi

### DIFF
--- a/pb_chime5/io/json_module.py
+++ b/pb_chime5/io/json_module.py
@@ -89,7 +89,7 @@ def dump_json(
         if create_path:
             path.parent.mkdir(parents=True, exist_ok=True)
 
-        with path.open('w') as f:
+        with path.open('w', encoding='utf8') as f:
             json.dump(obj, f, cls=Encoder, indent=indent,
                       sort_keys=sort_keys, **kwargs)
     else:
@@ -106,7 +106,7 @@ def load_json(path, **kwargs):
     assert isinstance(path, (str, Path)), path
     path = Path(path).expanduser()
 
-    with path.open() as fid:
+    with path.open(encoding='utf8') as fid:
         return json.load(fid, **kwargs)
 
 

--- a/pb_chime5/scripts/kaldi_run.py
+++ b/pb_chime5/scripts/kaldi_run.py
@@ -1,6 +1,6 @@
 """
 
-python -m pb_chime5.scripts.kaldi_run with storage_dir=<...> session_id=dev job_id=0 number_of_jobs=1
+python -m pb_chime5.scripts.kaldi_run with storage_dir=<...> session_id=dev job_id=1 number_of_jobs=1
 
 """
 
@@ -24,7 +24,7 @@ def config():
     session_id = 'dev'
     storage_dir: str = None
 
-    job_id = 0
+    job_id = 1
     number_of_jobs = 1
 
     assert storage_dir is not None, (storage_dir, 'overwrite the storage_dir from the command line')
@@ -53,7 +53,7 @@ def test_run(_run, storage_dir, test_run=True):
 def run(_run, storage_dir, job_id, number_of_jobs, session_id, test_run=False):
     print_config(_run)
 
-    assert job_id < number_of_jobs, (job_id, number_of_jobs)
+    assert job_id >= 1 and job_id <= number_of_jobs, (job_id, number_of_jobs)
 
     enhancer = get_enhancer()
 
@@ -61,7 +61,7 @@ def run(_run, storage_dir, job_id, number_of_jobs, session_id, test_run=False):
         print('Database', enhancer.db)
 
     if test_run is False:
-        dataset_slice = slice(job_id, None, number_of_jobs)
+        dataset_slice = slice(job_id - 1, None, number_of_jobs)
     else:
         dataset_slice = test_run
 


### PR DESCRIPTION
1. Kaldi scripts generally set encoding to ASCII. So in kaldi configured shell, files need to be opened explicitly using `encoding='utf8'`. (python3 uses by default the encoding set by the environment variables, which in a Kaldi setup is ASCII encoding.)
2. SGE requires job ids to be > 0.