### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ cache/chime5.json: cache
 	echo $(CHIME5_DIR)
 	python -m pb_chime5.database.chime5.create_json -j cache/chime5.json -db $(CHIME5_DIR) --transcription-path $(CHIME5_DIR)/transcriptions
 
-cache/chime6.json: cache CHIME6_DIR
+cache/chime6.json: cache $(CHIME6_DIR)
 	python -m pb_chime5.database.chime5.create_json -j cache/chime6.json -db $(CHIME6_DIR) --transcription-path $(CHIME6_DIR)/transcriptions --chime6
 
 $(CHIME6_DIR):


### PR DESCRIPTION
I just encountered the following error, which can be fixed by this PR.
```
make: *** No rule to make target 'CHIME6_DIR', needed by 'cache/chime6.json'.  Stop.
```