### PR TITLE
Disable number of utterance test for chime6, because the number of utterances changed

### DIFF
--- a/pb_chime5/database/chime5/create_json.py
+++ b/pb_chime5/database/chime5/create_json.py
@@ -253,10 +253,14 @@ def get_dataset(database_path, dataset, transcription_realigned_path, kaldi_tran
 
         total = len(trans)
         assert len(trans) == len(trans_realigned), (len(trans), len(trans_realigned))
-        if total < set_length[dataset][session_id]:
+        # ToDo: Fix this exception to test equality.
+        #       In chime6 the number of utterances changed -> Disabled at the moment
+        if chime6 or total < set_length[dataset][session_id]:
             raise ValueError(
                 f'missing utterances in session {session_id} expected length'
                 f' {set_length[dataset][session_id]} available length {total}')
+
+        assert total > 0, ('Each session should have at least one example', dataset_transciption_realigned_path[session_path.name])
         # elif total > set_length[dataset][session_id]:
         #     warn(f'there are {total - set_length[dataset][session_id]} examples'
         #           f' more than expected in session {session_id}')


### PR DESCRIPTION
The number of examples changed in CHiME6.
Disable the test that checks the number of examples.
Thanks to @sw005320 for reporting this.