### PR TITLE
Match example ID with kaldi for CHiME6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,11 @@ cache/chime5.json: cache
 	echo $(CHIME5_DIR)
 	python -m pb_chime5.database.chime5.create_json -j cache/chime5.json -db $(CHIME5_DIR) --transcription-path $(CHIME5_DIR)/transcriptions
 
-cache/chime6.json: cache $(CHIME6_DIR)
+cache/chime6.json: cache
 	python -m pb_chime5.database.chime5.create_json -j cache/chime6.json -db $(CHIME6_DIR) --transcription-path $(CHIME6_DIR)/transcriptions --chime6
 
 $(CHIME6_DIR):
+	# Generate a dummy CHiME 6 folder with invalid time stamps and audio files that aren't sync
 	python -m pb_chime5.scripts.simulate_chime6_transcriptions $(CHIME5_DIR) $(CHIME6_DIR)
 
 cache/annotation/S02.pkl: cache

--- a/jenkins.bash
+++ b/jenkins.bash
@@ -29,6 +29,7 @@ git submodule update
 pip install --user -e pb_bss/
 pip install --user -e .
 
+
 make cache/chime5.json
 make cache/annotation/S02.pkl
 python -m pb_chime5.scripts.run test_run with session_id=dev
@@ -37,6 +38,7 @@ python -m pb_chime5.scripts.run test_run with session_id=dev wpe=False activity_
 mkdir kaldi_run_storage_dir
 python -m pb_chime5.scripts.kaldi_run with storage_dir=kaldi_run_storage_dir session_id=dev job_id=1 number_of_jobs=2000
 
+make cache/CHiME6
 make cache/chime6.json
 python -m pb_chime5.scripts.run test_run with session_id=dev database_path=cache/chime6.json chime6=True
 mkdir kaldi_run_storage_dir_chime6

--- a/pb_chime5/database/chime5/create_json.py
+++ b/pb_chime5/database/chime5/create_json.py
@@ -364,6 +364,7 @@ def get_example(transcription, transcription_realigned, audio_path, kaldi_transc
         end_sample=end_sample,
         session_id=session_id,
         speaker_id=target_speaker_id,
+        chime6=chime6,
     )
 
     arrays = [f'U0{array+1}' for array in range(NUM_ARRAYS)]
@@ -474,6 +475,7 @@ def get_example_id(
         end_sample,
         speaker_id,
         session_id,
+        chime6,
 ):
     """
     >>> get_example_id(45963520, 45987360, 'P09', 'S03')
@@ -482,7 +484,10 @@ def get_example_id(
     """
     start_sample_str = str(int(start_sample * 100 / SAMPLE_RATE)).zfill(7)
     end_sample_str = str(int(end_sample * 100 / SAMPLE_RATE)).zfill(7)
-    return f'{speaker_id}_{session_id}_{start_sample_str}-{end_sample_str}'
+    if chime6:
+        return f'{speaker_id}_{session_id}-{start_sample_str}-{end_sample_str}'
+    else:
+        return f'{speaker_id}_{session_id}_{start_sample_str}-{end_sample_str}'
 
 
 from functools import lru_cache


### PR DESCRIPTION
@sw005320: This PR matches the IDs with kaldi for CHiME 6.
I only changed it for CHiME-6, because I do not want to make a breaking change for CHiME 5.

When jenkins finished testing this PR, I will do the merge.