### PR TITLE
Add reference_array option for train

### DIFF
--- a/pb_chime5/core_chime6.py
+++ b/pb_chime5/core_chime6.py
@@ -295,6 +295,7 @@ class Enhancer:
 
     context_samples: int  # e.g. 240000
     multiarray: bool
+    reference_array: [None, str]
 
     @property
     def db(self):

--- a/pb_chime5/core_chime6.py
+++ b/pb_chime5/core_chime6.py
@@ -397,7 +397,6 @@ class Enhancer:
             debug=False,
     ):
         session_id = ex['session_id']
-        reference_array = ex['reference_array']
         speaker_id = ex['speaker_id']
 
         array_start = ex['start']
@@ -465,6 +464,20 @@ class Enhancer:
                 for array in sorted(ex['audio_path']['observation'].keys())
             ]))
         elif self.multiarray is False:
+            reference_array = self.reference_array
+            if reference_array is None:
+                try:
+                    reference_array = ex['reference_array']
+                except KeyError:
+                    raise RuntimeError(
+                        'Failed to get the "reference_array" from the example.\n'
+                        'Probably you tried to enhance the "train" dataset.\n'
+                        'Train has no "reference_array".\n'
+                        'You can set a "reference_array" from the commandline with\n'
+                        '\tpython -m ... with ... reference_array=U06\n'
+                        'In case of multiarray, the reference array is used for the'
+                        'projection of the human annotations.'
+                    ) from None
             obs = load_audio(
                 ex['audio_path']['observation'][reference_array],
                 start=ex['start'],
@@ -601,7 +614,7 @@ def get_enhancer(
             type=activity_type,
             garbage_class=activity_garbage_class,
             path=activity_path,
-            database_path=str(database_path),
+            database_path=database_path,
         ),
         gss_block=GSS(
             iterations=bss_iterations,

--- a/pb_chime5/core_chime6.py
+++ b/pb_chime5/core_chime6.py
@@ -604,6 +604,7 @@ def get_enhancer(
 
     return Enhancer(
         multiarray=multiarray,
+        reference_array=reference_array,
         context_samples=context_samples,
         wpe_block=WPE(
             taps=wpe_tabs,

--- a/pb_chime5/core_chime6.py
+++ b/pb_chime5/core_chime6.py
@@ -572,6 +572,7 @@ class Enhancer:
 def get_enhancer(
     multiarray=False,
     context_samples=240000,
+    reference_array=None,
 
     wpe=True,
     wpe_tabs=10,


### PR DESCRIPTION
When enhancing training data, the `reference_array` is not defined. This PR adds an option to fix the reference_array to one array.